### PR TITLE
Remove unnecessary hamburger menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,6 @@
   </head>
 
   <body>
-    <!-- This example requires Tailwind CSS v2.0+ -->
     <div class="relative bg-white overflow-hidden">
       <div class="max-w-7xl mx-auto">
         <div
@@ -51,94 +50,6 @@
           >
             <polygon points="50,0 100,0 50,100 0,100" />
           </svg>
-
-          <div class="relative pt-6 px-4 sm:px-6 lg:px-8">
-            <nav
-              class="relative flex items-center justify-between sm:h-10 lg:justify-start"
-              aria-label="Global"
-            >
-              <div
-                class="flex items-center flex-grow flex-shrink-0 lg:flex-grow-0"
-              >
-                <div class="flex items-center justify-between w-full md:w-auto">
-                  <a href="#">
-                    <span class="sr-only">Workflow</span>
-                    <img class="h-8 w-auto sm:h-10" src="logo.png" />
-                  </a>
-                  <div class="-mr-2 flex items-center md:hidden">
-                    <button
-                      type="button"
-                      class="bg-white rounded-md p-2 inline-flex items-center justify-center text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-red-500"
-                      id="main-menu"
-                      aria-haspopup="true"
-                    >
-                      <span class="sr-only">Open main menu</span>
-                      <!-- Heroicon name: menu -->
-                      <svg
-                        class="h-6 w-6"
-                        xmlns="http://www.w3.org/2000/svg"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                        aria-hidden="true"
-                      >
-                        <path
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          d="M4 6h16M4 12h16M4 18h16"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </nav>
-          </div>
-
-          <!--
-          Mobile menu, show/hide based on menu open state.
-  
-          Entering: "duration-150 ease-out"
-            From: "opacity-0 scale-95"
-            To: "opacity-100 scale-100"
-          Leaving: "duration-100 ease-in"
-            From: "opacity-100 scale-100"
-            To: "opacity-0 scale-95"
-        -->
-          <div
-            class="absolute top-0 inset-x-0 p-2 transition transform origin-top-right md:hidden"
-          >
-            <div
-              class="rounded-lg shadow-md bg-white ring-1 ring-black ring-opacity-5 overflow-hidden"
-            >
-              <div class="px-5 pt-4 flex items-center justify-between">
-                <div>
-                  <img
-                    class="h-8 w-auto"
-                    src="https://tailwindui.com/img/logos/workflow-mark-red-600.svg"
-                    alt=""
-                  />
-                </div>
-                <div class="-mr-2">
-                  <button
-                    type="button"
-                    class="bg-white rounded-md p-2 inline-flex items-center justify-center text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-red-500"
-                  >
-                    <span class="sr-only">Close main menu</span>
-                    <!-- Heroicon name: x -->
-                    <img src="logo.png" />
-                  </button>
-                </div>
-              </div>
-              <div
-                role="menu"
-                aria-orientation="vertical"
-                aria-labelledby="main-menu"
-              >
-              </div>
-            </div>
-          </div>
 
           <main
             class="mt-10 mx-auto max-w-7xl px-4 sm:mt-12 sm:px-6 md:mt-16 lg:mt-20 lg:px-8 xl:mt-28"

--- a/index.html
+++ b/index.html
@@ -51,6 +51,23 @@
             <polygon points="50,0 100,0 50,100 0,100" />
           </svg>
 
+          <div class="relative pt-6 px-4 sm:px-6 lg:px-8">
+            <nav
+              class="relative flex items-center justify-between sm:h-10 lg:justify-start"
+              aria-label="Global"
+            >
+              <div
+                class="flex items-center flex-grow flex-shrink-0 lg:flex-grow-0"
+              >
+                <div class="flex items-center justify-between w-full md:w-auto">
+                  <img class="h-8 w-auto sm:h-10" src="logo.png" />
+                  <div class="-mr-2 flex items-center md:hidden">
+                  </div>
+                </div>
+              </div>
+            </nav>
+          </div>
+
           <main
             class="mt-10 mx-auto max-w-7xl px-4 sm:mt-12 sm:px-6 md:mt-16 lg:mt-20 lg:px-8 xl:mt-28"
           >


### PR DESCRIPTION
We have a code for hamburger menu for mobile, but:
1. It has no links
2. It has always opened state blocking header on mobile

I removed hidden menu and button

Before:

![Captura desde 2023-09-08 14-17-16](https://github.com/BarcelonaJS/barcelonajs.com/assets/19343/3e346d23-105d-44b1-b88f-4254a1f0fd77)

![Captura desde 2023-09-08 14-17-24](https://github.com/BarcelonaJS/barcelonajs.com/assets/19343/057d2146-7e59-4c5d-8f00-479f1151e863)